### PR TITLE
Change container ports, fix up etcd group/user perms, add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+default.etcd
+*.pyc

--- a/10-yaobank.yaml
+++ b/10-yaobank.yaml
@@ -33,8 +33,8 @@ spec:
       serviceAccountName: database
       containers:
       - name: database
-        image: spikecurtis/yaobank-database:latest
-        imagePullPolicy: IfNotPresent
+        image: calico/yaobank-database:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 2379
         command: ["etcd"]
@@ -54,6 +54,7 @@ spec:
   ports:
   - port: 80
     name: http
+    targetPort: 8000
   selector:
     app: summary
 ---
@@ -80,10 +81,10 @@ spec:
       serviceAccountName: summary
       containers:
       - name: summary
-        image: spikecurtis/yaobank-summary:latest
+        image: calico/yaobank-summary:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 80
+        - containerPort: 8000
 ---
 apiVersion: v1
 kind: Service
@@ -95,6 +96,7 @@ spec:
   ports:
   - port: 80
     name: http
+    targetPort: 8000
   selector:
     app: customer
 ---
@@ -121,8 +123,8 @@ spec:
       serviceAccountName: customer
       containers:
       - name: customer
-        image: spikecurtis/yaobank-customer:latest
+        image: calico/yaobank-customer:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 80
+        - containerPort: 8000
 ---

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,21 @@ ETCD_VERSION ?= v3.3.7
 # Constants
 PYTHON_VERSION ?= 2.7
 
+.PHONY: calico/yaobank-customer
 calico/yaobank-customer:
 	docker build -t $@ customer
 
+.PHONY: calico/yaobank-summary
 calico/yaobank-summary:
 	docker build -t $@ summary
 
-calico/yaobank-database:
+.PHONY: calico/yaobank-database
+calico/yaobank-database: database/default.etcd
+	# Create a packaged etcd with the populated data (this also modifies group/user settings for this data which is
+	# required for OpenShift).
+	docker build -t $@ database
+
+database/default.etcd: database/data.txt database/loaddata.py
 	# Start an etcd server
 	-docker rm -f yaobank-etcd
 	docker run --detach \
@@ -27,14 +35,25 @@ calico/yaobank-database:
 	# Copy out the default.etcd data from the etcd container and delete the etcd container
 	docker cp yaobank-etcd:/default.etcd $(CURDIR)/database
 	docker rm -f yaobank-etcd
-	# Create a packaged etcd with the populated data (this also modifies group/user settings for this data which is
-	# required for OpenShift).
-	docker build -t $@ database
 
-release:
-	$(MAKE) calico/yaobank-customer
-	$(MAKE) calico/yaobank-summary
-	$(MAKE) calico/yaobank-database
+.PHONY: clean
+clean:
+	-rm -rf database/default.etcd
+	-docker rmi calico/yaobank-customer:latest
+	-docker rmi calico/yaobank-summary:latest
+	-docker rmi calico/yaobank-database:latest
+	-docker rmi calico/yaobank-customer:$(VERSION)
+	-docker rmi calico/yaobank-summary:$(VERSION)
+	-docker rmi calico/yaobank-database:$(VERSION)
+	-docker rmi quay.io/calico/yaobank-customer:latest
+	-docker rmi quay.io/calico/yaobank-summary:latest
+	-docker rmi quay.io/calico/yaobank-database:latest
+	-docker rmi quay.io/calico/yaobank-customer:$(VERSION)
+	-docker rmi quay.io/calico/yaobank-summary:$(VERSION)
+	-docker rmi quay.io/calico/yaobank-database:$(VERSION)
+
+.PHONY: release
+release: calico/yaobank-customer calico/yaobank-summary calico/yaobank-database
 	docker tag calico/yaobank-customer:latest calico/yaobank-customer:$(VERSION)
 	docker tag calico/yaobank-summary:latest calico/yaobank-summary:$(VERSION)
 	docker tag calico/yaobank-database:latest calico/yaobank-database:$(VERSION)
@@ -45,6 +64,7 @@ release:
 	docker tag calico/yaobank-summary:latest quay.io/calico/yaobank-summary:$(VERSION)
 	docker tag calico/yaobank-database:latest quay.io/calico/yaobank-database:$(VERSION)
 
+.PHONY: push
 push:
 	docker push calico/yaobank-customer:latest
 	docker push calico/yaobank-summary:latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+# The release version.
+VERSION ?= v0.1
+
+# Etcd version. Should match the version in the database/Dockerfile.
+ETCD_VERSION ?= v3.3.7
+
+# Constants
+PYTHON_VERSION ?= 2.7
+
+calico/yaobank-customer:
+	docker build -t $@ customer
+
+calico/yaobank-summary:
+	docker build -t $@ summary
+
+calico/yaobank-database:
+	# Start an etcd server
+	-docker rm -f yaobank-etcd
+	docker run --detach \
+	  --net=host \
+	  --entrypoint=/usr/local/bin/etcd \
+	  --name yaobank-etcd quay.io/coreos/etcd:$(ETCD_VERSION) \
+	  --advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:2379,http://$(LOCAL_IP_ENV):4001,http://127.0.0.1:4001" \
+	  --listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"
+	# Run the python population script
+	docker run --net=host -v $(CURDIR)/database:/database python:$(PYTHON_VERSION) sh -c "pip install python-etcd && cd /database && python loaddata.py"
+	# Copy out the default.etcd data from the etcd container and delete the etcd container
+	docker cp yaobank-etcd:/default.etcd $(CURDIR)/database
+	docker rm -f yaobank-etcd
+	# Create a packaged etcd with the populated data (this also modifies group/user settings for this data which is
+	# required for OpenShift).
+	docker build -t $@ database
+
+release:
+	$(MAKE) calico/yaobank-customer
+	$(MAKE) calico/yaobank-summary
+	$(MAKE) calico/yaobank-database
+	docker tag calico/yaobank-customer:latest calico/yaobank-customer:$(VERSION)
+	docker tag calico/yaobank-summary:latest calico/yaobank-summary:$(VERSION)
+	docker tag calico/yaobank-database:latest calico/yaobank-database:$(VERSION)
+	docker tag calico/yaobank-customer:latest quay.io/calico/yaobank-customer:latest
+	docker tag calico/yaobank-summary:latest quay.io/calico/yaobank-summary:latest
+	docker tag calico/yaobank-database:latest quay.io/calico/yaobank-database:latest
+	docker tag calico/yaobank-customer:latest quay.io/calico/yaobank-customer:$(VERSION)
+	docker tag calico/yaobank-summary:latest quay.io/calico/yaobank-summary:$(VERSION)
+	docker tag calico/yaobank-database:latest quay.io/calico/yaobank-database:$(VERSION)
+
+push:
+	docker push calico/yaobank-customer:latest
+	docker push calico/yaobank-summary:latest
+	docker push calico/yaobank-database:latest
+	docker push calico/yaobank-customer:$(VERSION)
+	docker push calico/yaobank-summary:$(VERSION)
+	docker push calico/yaobank-database:$(VERSION)
+	docker push quay.io/calico/yaobank-customer:latest
+	docker push quay.io/calico/yaobank-summary:latest
+	docker push quay.io/calico/yaobank-database:latest
+	docker push quay.io/calico/yaobank-customer:$(VERSION)
+	docker push quay.io/calico/yaobank-summary:$(VERSION)
+	docker push quay.io/calico/yaobank-database:$(VERSION)

--- a/customer/customer.py
+++ b/customer/customer.py
@@ -12,4 +12,4 @@ def home():
 	return render_template("accountsummary.html", **summary)
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=80)
+    app.run(host="0.0.0.0", port=8000)

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,6 @@
+FROM quay.io/coreos/etcd:v3.3.7
+
+# Copy in the default data files and set group/user permissions.
+COPY default.etcd /default.etcd
+RUN chgrp -R 0 /default.etcd && \
+    chmod -R g=u /default.etcd

--- a/summary/summary.py
+++ b/summary/summary.py
@@ -15,4 +15,4 @@ def get_summary(userid):
     return jsonify(summary)
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=80)
+    app.run(host="0.0.0.0", port=8000)


### PR DESCRIPTION
This PR moves yaobank demo in to the project calico repo.  It makes a few minor improvements:

- Update container ports to be 8000 rather than 80.  This is for OpenShift compatibility which requires ports > 1xxx (can't remember the exact number)
- Set etcd data file group/user perms so that it's not necessary to create a security context when running in OpenShift.
- Add a Makefile to build/push each container image (very basic)